### PR TITLE
fix: Unpin setuptools to resolve build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ python-telegram-bot==20.3
 pandas-ta==0.3.14b0
 scipy==1.10.1
 tabulate==0.9.0
-setuptools==68.2.2
+setuptools
 fastapi==0.103.2
 uvicorn[standard]==0.23.2


### PR DESCRIPTION
This commit modifies the `requirements.txt` file to unpin the `setuptools` dependency.

The previous version of `requirements.txt` had `setuptools` pinned to version `68.2.2`. This was causing a `pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'` error during deployment on environments using newer versions of Python (e.g., Python 3.13), where packages like `pandas` and `numpy` need to be built from source.

By removing the version pin, we allow `pip` to select a version of `setuptools` that is compatible with the build environment, which should resolve the build failure.