### PR TITLE
fix: Update core dependencies for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pandas==1.5.3
-numpy==1.23.5
-tensorflow==2.12.0
+pandas
+numpy
+tensorflow
 absl-py==1.4.0
 tqdm==4.66.1
 scikit-learn==1.2.2


### PR DESCRIPTION
This commit modifies the `requirements.txt` file to unpin the versions of `pandas`, `numpy`, and `tensorflow`.

The previously pinned versions were old and not compatible with the Python 3.13 environment used for deployment, causing a build failure related to `setuptools.build_meta`.

Unpinning these core scientific and machine learning libraries allows `pip` to resolve and install the latest compatible versions, which should fix the build process on modern Python environments.