### PR TITLE
fix: Unpin scikit-learn and scipy for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ numpy
 tensorflow
 absl-py==1.4.0
 tqdm==4.66.1
-scikit-learn==1.2.2
+scikit-learn
 matplotlib==3.7.1
 python-binance==1.0.19
 python-telegram-bot==20.3
 pandas-ta==0.3.14b0
-scipy==1.10.1
+scipy
 tabulate==0.9.0
 setuptools
 fastapi==0.103.2


### PR DESCRIPTION
This is a follow-up to the previous dependency fixes. The build process was still failing during the installation of `scikit-learn`, with Cython compilation errors indicating an incompatibility with the Python 3.13 environment.

This commit further modifies the `requirements.txt` file to unpin the versions of `scikit-learn` and `scipy`. By unpinning all major scientific computing libraries (`pandas`, `numpy`, `tensorflow`, `scikit-learn`, `scipy`), `pip` is given the flexibility to find a fully compatible set of dependencies for the target environment.

This change should resolve the remaining build failures.