### PR TITLE
fix: Unpin pandas-ta for numpy compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ scikit-learn
 matplotlib==3.7.1
 python-binance==1.0.19
 python-telegram-bot==20.3
-pandas-ta==0.3.14b0
+pandas-ta
 scipy
 tabulate==0.9.0
 setuptools


### PR DESCRIPTION
This commit resolves an `ImportError` that occurred at application startup. The error, `ImportError: cannot import name 'NaN' from 'numpy'`, was caused by an old, pinned version of `pandas-ta` being incompatible with the modern version of `numpy` required by the Python 3.13 environment.

This change unpins `pandas-ta` in the `requirements.txt` file, allowing the package manager (`pip`) to install a newer, compatible version. This should resolve the final dependency conflict and allow the application to run successfully.