### PR TITLE
fix: Add monkey-patch for numpy.NaN import error

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ import telegram
 from telegram.ext import ApplicationBuilder, CommandHandler, JobQueue, ConversationHandler, CallbackQueryHandler
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 import numpy as np
+if not hasattr(np, 'NaN'):
+    np.NaN = np.nan
 import json
 import pytz
 import matplotlib


### PR DESCRIPTION
This commit introduces a workaround for a persistent `ImportError` that occurs on application startup.

The error, `ImportError: cannot import name 'NaN' from 'numpy'`, is caused by an old version of the `pandas-ta` library being used in the deployment environment, which is incompatible with modern `numpy` versions. Despite multiple attempts to fix this by updating the `requirements.txt` file, the issue persists, likely due to a stubborn caching or dependency resolution problem in the deployment environment.

This commit adds a monkey-patch to the top of `main.py`. The patch checks if the `numpy.NaN` attribute exists and, if not, creates it by assigning the value of `numpy.nan`. This ensures that when the old `pandas-ta` library tries to perform `from numpy import NaN`, the import succeeds, preventing the application from crashing.

This is a pragmatic workaround to ensure the application can run in the target environment.