### PR TITLE
fix: Add missing keras-tuner dependency and remove redundant install …

### DIFF
--- a/ML.py
+++ b/ML.py
@@ -1,21 +1,5 @@
 import os
-import subprocess
 import sys
-
-def install_dependencies():
-    """
-    Installs all required libraries from requirements.txt.
-    """
-    print("--- Installing dependencies from requirements.txt ---")
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
-        print("--- Dependencies installed successfully ---")
-    except subprocess.CalledProcessError as e:
-        print(f"Failed to install dependencies: {e}")
-        sys.exit(1)
-
-# Install dependencies before other imports
-install_dependencies()
 
 # Set TensorFlow logging level to suppress all but error messages
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ tabulate==0.9.0
 setuptools
 fastapi==0.103.2
 uvicorn[standard]==0.23.2
+keras-tuner


### PR DESCRIPTION
…script

This commit addresses two issues that were preventing a successful deployment:

1.  A `ModuleNotFoundError: No module named 'keras_tuner'` was occurring at runtime. The `keras-tuner` package has now been added to `requirements.txt` to resolve this.

2.  A redundant `install_dependencies()` function was being called at the top of `ML.py`. This function was re-installing all dependencies from `requirements.txt` on every application start, which is inefficient and not best practice for a deployment environment. This function and its call have been removed.

These changes should resolve the final issues and allow the application to deploy and run successfully.