### PR TITLE
Fix RuntimeError in Telegram bot polling thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -2797,8 +2797,12 @@ async def lifespan(app: FastAPI):
     op_handler = CommandHandler('op', op_command)
     application.add_handler(op_handler)
 
+    def run_polling_in_thread(app):
+        """Target for the thread that runs the bot."""
+        asyncio.run(app.run_polling())
+
     # Run the bot in a separate thread
-    thread = threading.Thread(target=application.run_polling)
+    thread = threading.Thread(target=run_polling_in_thread, args=(application,))
     thread.daemon = True
     thread.start()
 


### PR DESCRIPTION
The application was encountering a `RuntimeError: There is no current event loop in thread` when starting the `python-telegram-bot` polling mechanism within a separate thread. This is because `application.run_polling` is a coroutine and requires an asyncio event loop, but a new thread doesn't have one by default.

This change resolves the issue by creating a wrapper function, `run_polling_in_thread`, which uses `asyncio.run()` to manage a new event loop within the thread. The thread is then started with this wrapper function as its target. This ensures the bot's async polling runs correctly in its own thread without conflicting with the main Uvicorn/FastAPI event loop.