### PR TITLE
Fix threading errors in Telegram bot and FastAPI integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -2802,7 +2802,9 @@ async def lifespan(app: FastAPI):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
-            loop.run_until_complete(app.run_polling())
+            # Pass stop_signals=[] to prevent ValueError: add_signal_handler()
+            # can only be called from the main thread.
+            loop.run_until_complete(app.run_polling(stop_signals=[]))
         finally:
             loop.close()
 


### PR DESCRIPTION
This commit resolves two issues that occur when running the `python-telegram-bot` polling mechanism in a separate thread alongside a FastAPI/Uvicorn server:

1.  A `RuntimeError: There is no current event loop in thread` is fixed by creating a wrapper function that manually creates a new `asyncio` event loop for the polling thread and runs the coroutine within it.

2.  A subsequent `ValueError: add_signal_handler() can only be called from the main thread` is fixed by passing `stop_signals=[]` to the `application.run_polling()` method. This prevents the library from attempting to register signal handlers in a non-main thread, which is not allowed in Python.

The combination of these two changes ensures that the bot's async polling runs correctly in its own thread without conflicting with the main server thread or violating Python's signal handling constraints.