### PR TITLE
refactor: Separate web server and bot worker processes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: uvicorn main:app --host 0.0.0.0 --port 8080
+worker: python main.py --worker


### PR DESCRIPTION
Resolves `telegram.error.Conflict` by ensuring only one instance of the Telegram bot is polling for updates.

The previous implementation started the bot's polling mechanism within the FastAPI application's lifespan manager. When deployed on a platform like Render, this could lead to multiple web server instances, each trying to poll Telegram, causing a conflict.

This commit refactors the application to run as two separate processes, a standard pattern for this type of application:

1.  **Web Process:** A `uvicorn` process that serves the FastAPI app. Its only responsibility is to handle HTTP requests. The bot logic has been removed from its startup sequence.
2.  **Worker Process:** A new `worker` process, defined in the `Procfile`, which runs the Telegram bot. It is started with a `--worker` flag. The hosting platform should be configured to run only a single instance of this worker.

This change isolates the long-running polling task to a single process, guaranteeing that there are no conflicts, while allowing the web server to be scaled independently if needed. The unreliable file-based lock has been removed in favor of this more robust process-based separation.